### PR TITLE
travis: skip docs-only commit range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,16 @@ matrix:
           packages:
             - binutils-arm-none-eabi
 
-before_install: set -e
+before_install:
+- |
+    set -e
+    # fail loudly when force-pushed
+    MODIFIED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+    # waiting for native solution https://github.com/travis-ci/travis-ci/issues/6301
+    if ! echo ${MODIFIED_FILES} | grep -qvE '(\.md$)|(^docs)/'; then
+      echo "Only docs were updated, stopping build process."
+      exit
+    fi
 
 install:
   - bash ./scripts/install.sh


### PR DESCRIPTION
Adapted from facebook/react#2000 with the last state in https://github.com/facebook/react/commit/fc15d702b81f2edd608568733409918f8fa71763#diff-354f30a63fb0907d4ad57269548329e3L19

cf travis-ci/travis-ci#6301

Close #2.