### PR TITLE
README: change discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Not yet implemented:
 Community
 ---------
 
-We hang out in the [Anne Pro discord](https://discord.gg/ARQmrNn). Please observe the [Rust Code of Conduct](https://rust-lang.org/conduct.html) within our community.
+We hang out in the [Anne Pro Dev discord](https://discord.gg/ARQmrNn). Please observe the [Rust Code of Conduct](https://rust-lang.org/conduct.html) within our community.
 
 Documentation
 ---------

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Not yet implemented:
 Community
 ---------
 
-We hang out in the [Anne Pro discord](https://discord.gg/vZrBPQJ). Please observe the [Rust Code of Conduct](https://rust-lang.org/conduct.html) within our community.
+We hang out in the [Anne Pro discord](https://discord.gg/ARQmrNn). Please observe the [Rust Code of Conduct](https://rust-lang.org/conduct.html) within our community.
 
 Documentation
 ---------


### PR DESCRIPTION
Change the discord link to the actual one used by the devs, instead of the generic "obins" one.