### PR TITLE
travis: temporarily pin rust to nightly 2018-03-02

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 matrix:
   include:
     - env: TARGET=thumbv7m-none-eabi
-      rust: nightly
+      rust: nightly-2018-03-02
       addons:
         apt:
           sources:


### PR DESCRIPTION
2018-03-03 introduces build failure because libcore cannot find its `mod coresimd`. Travis build: https://travis-ci.org/hdhoang/anne-key/builds/348858559#L498

As part of rust-lang/rust#48513, `src/stdsimd` is a submodule. I guess it is not included in the rust-src component yet? ping @alexcrichton