### PR TITLE
Add LedToggle function for FN+R

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -15,6 +15,7 @@ pub enum Action {
 
     LedOn, // = 0x30,
     LedOff,
+    LedToggle,
     LedNextTheme,
     LedNextBrightness,
     LedNextAnimationSpeed,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -147,6 +147,7 @@ impl<'a> EventProcessor for Led<'a> {
             let result = match action {
                 &Action::LedOn => self.on(),
                 &Action::LedOff => self.off(),
+		&Action::LedToggle => self.toggle(),
                 &Action::LedNextTheme => self.next_theme(),
                 &Action::LedNextBrightness => self.next_brightness(),
                 &Action::LedNextAnimationSpeed => self.next_animation_speed(),

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -39,11 +39,11 @@ pub const BASE: Layout = layout![
 ];
 
 pub const FN: Layout = layout![
-  Grave F1   F2   F3    F4    F5     F6    F7      F8   F9         F10    F11    F12    __
-  __    __   Up   __    LedOn LedNAS LedNB LedNT   Up   Scrolllock Pause  Home   End    PScreen
-  __    Left Down Right __    __     __    Left    Down Right      PgUp   PgDown No     __
-  __    __   __   __    __    __     __    __      __   Insert     Delete No     No     __
-  __    __   __   No    No    __     No    No      No   No         __     __     __     __
+  Grave F1   F2   F3    F4        F5     F6    F7      F8   F9         F10    F11    F12    __
+  __    __   Up   __    LedToggle LedNAS LedNB LedNT   Up   Scrolllock Pause  Home   End    PScreen
+  __    Left Down Right __        __     __    Left    Down Right      PgUp   PgDown No     __
+  __    __   __   __    __        __     __    __      __   Insert     Delete No     No     __
+  __    __   __   No    No        __     No    No      No   No         __     __     __     __
 ];
 
 pub const LED: Layout = layout![

--- a/src/led.rs
+++ b/src/led.rs
@@ -15,6 +15,7 @@ pub struct Led<'a> {
     pub serial: Serial<'a, LedUsart>,
     pub rx_transfer: Option<Transfer>,
     pub pc15: PC15<Output>,
+    pub state: bool
 }
 
 impl<'a> Led<'a> {
@@ -24,6 +25,7 @@ impl<'a> Led<'a> {
             serial: serial,
             rx_transfer: Some(rx_transfer),
             pc15: pc15.into_output().pull_up(),
+            state: true
         }
     }
 
@@ -35,6 +37,16 @@ impl<'a> Led<'a> {
     pub fn off(&mut self) -> nb::Result<(), !> {
         self.pc15.set_low();
         Ok(())
+    }
+
+    pub fn toggle(&mut self) -> nb::Result<(), !> {
+        if(!self.state){
+            self.pc15.set_high();
+	} else {
+	    self.pc15.set_low();
+        }
+	self.state = !self.state;
+	Ok(())
     }
 
     // next_* cycles through themes/brightness/speed


### PR DESCRIPTION
This adds a state to the LED struct which is used in a toggle() function to bring the FN+R functionality closer to the stock firmware

The function currently still lacks a way to switch the LEDs to the last used theme (instead FN+U should be used after turning on the LEDs)

Sending a ```self.serial``` command to show the next theme right after ```self.pc15.set_high();``` seems to work very rarely if at all.
I assume it needs to wait until the LED chip is actually listening before sending the command but I'm not sure if there is a callback for that(?)