### PR TITLE
[WIP] BT led: color more keys

### DIFF
--- a/src/led.rs
+++ b/src/led.rs
@@ -123,7 +123,7 @@ where
             KeyIndex::N4 as u8,     0xff, 0x00, 0x00, LedMode::On as u8,
             KeyIndex::Equal as u8,  0x00, 0xff, 0x00, LedMode::On as u8,
             KeyIndex::B as u8,      0x00, 0xff, 0x00, LedMode::Flash as u8,
-            KeyIndex::Minus as u8,     0x00, 0xff, 0x00, LedMode::On as u8,
+            KeyIndex::Minus as u8,  0xff, 0x00, 0x00, LedMode::On as u8,
             KeyIndex::N0 as u8,  mode_color.0, mode_color.1, mode_color.2, LedMode::On as u8,
             KeyIndex::A as u8,      0x00, 0xff, 0x00, LedMode::On as u8,
         ];

--- a/src/led.rs
+++ b/src/led.rs
@@ -109,7 +109,7 @@ where
 
     pub fn bluetooth_mode(&mut self, mode: BluetoothMode) -> nb::Result<(), !> {
         let mode_color = match mode {
-            BluetoothMode::Unknown => (0, 0, 0xff),
+            BluetoothMode::Unknown => (0xff, 0, 0),
             BluetoothMode::Ble => (0, 0xff, 0),
             BluetoothMode::Legacy => (0xff, 0xff, 0),
         };

--- a/src/led.rs
+++ b/src/led.rs
@@ -115,7 +115,8 @@ where
         };
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
-        let payload = &[0xca, 0x0f,
+        let payload = &[0xca,
+                        0x0f, // the following data's length
             KeyIndex::Escape as u8, 0xff, 0xff, 0x00, LedMode::On as u8,
             // Select host
             KeyIndex::N1 as u8,     0xff, 0x00, 0x00, LedMode::Flash as u8,

--- a/src/led.rs
+++ b/src/led.rs
@@ -115,13 +115,20 @@ where
         };
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
-        let payload = &[0xca, 0x0a,
+        let payload = &[0xca, 0x0f,
             KeyIndex::Escape as u8, 0xff, 0xff, 0x00, LedMode::On as u8,
+            // Select host
             KeyIndex::N1 as u8,     0xff, 0x00, 0x00, LedMode::Flash as u8,
             KeyIndex::N2 as u8,     0xff, 0x00, 0x00, LedMode::On as u8,
             KeyIndex::N3 as u8,     0xff, 0x00, 0x00, LedMode::On as u8,
             KeyIndex::N4 as u8,     0xff, 0x00, 0x00, LedMode::On as u8,
+            // Save host
+            KeyIndex::Q as u8,      0x00, 0x00, 0xff, LedMode::On as u8,
+            KeyIndex::W as u8,      0x00, 0x00, 0xff, LedMode::On as u8,
+            KeyIndex::E as u8,      0x00, 0x00, 0xff, LedMode::On as u8,
+            KeyIndex::R as u8,      0x00, 0x00, 0xff, LedMode::On as u8,
             KeyIndex::Equal as u8,  0x00, 0xff, 0x00, LedMode::On as u8,
+            KeyIndex::BSpace as u8, 0x00, 0x00, 0xff, LedMode::On as u8,
             KeyIndex::B as u8,      0x00, 0xff, 0x00, LedMode::Flash as u8,
             KeyIndex::Minus as u8,  0xff, 0x00, 0x00, LedMode::On as u8,
             KeyIndex::N0 as u8,  mode_color.0, mode_color.1, mode_color.2, LedMode::On as u8,


### PR DESCRIPTION
Besides stock keys, we use QWER to save host and BSpace for BtOn.

I have some more planned:
- [ ] red ASDF for delete host (since we haven't implemented stock's A anyway)
- [ ] Something for RCtrl
- [x] red 0 for unknown BLE status (currently blue)

I would like your comment on these.