### PR TITLE
Optimize for binary size

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,6 +6,3 @@ rustflags = [
   "-Z", "linker-flavor=ld",
   "-Z", "thinlto=no",
 ]
-
-#[build]
-#target = "thumbv7m-none-eabi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: rust
 
 matrix:
   include:
-    - env: TARGET=thumbv7m-none-eabi
-      rust: nightly
+    - rust: nightly
       addons:
         apt:
           sources:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,9 @@ version = "0.1.0"
 [profile.release]
 debug = true
 lto = true
+opt-level = "z"
 
 [profile.dev]
 debug = true
 lto = false
-opt-level = 3
+opt-level = "z"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,6 @@
 set -eux
 
 main() {
-    if [ $TARGET = thumbv7m-none-eabi ]; then
         # This fetches latest stable release of Xargo
         local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/xargo \
                         | cut -d/ -f3 \
@@ -25,7 +24,6 @@ main() {
             rustup component add rustfmt-preview
 
         which cargo-bloat || cargo install cargo-bloat
-    fi
 }
 
 main


### PR DESCRIPTION
With `opt-level = "z"`, .text section went down by 3.5KB from 18.5KB in travis build 140.

The target commit is mostly cosmetic. It introduces a wrinkle where `cargo install` within this project will target the ARM instead of the host. I can replace this whole part with a note to that effect if you prefer.