### PR TITLE
Pack keystate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.0.2"
 
 [dependencies]
 bare-metal = "0.1.1"
+bit_field = "0.9.0"
 cortex-m = "0.4.3"
 cortex-m-semihosting = "0.2.0"
 cortex-m-rtfm = "0.3.1"

--- a/src/keymatrix.rs
+++ b/src/keymatrix.rs
@@ -28,6 +28,16 @@ type ColumnPins = (
     PB5<Output>,
 );
 
+/// The currently pressed down keys
+///
+/// A 72-bit array where the most-significant 2 bits are unused.
+/// Each key's state is stored as 1 (pressed) or 0 (released) at
+/// the bit indexed by the corresponding `keycodes::KeyIndex`,
+/// namely Escape is at bit 0 (least-significant bit), and RCtrl
+/// is at bit 69.
+///
+/// This packed format is used as-is when sending key-state to
+/// stock LED firmware.
 pub type KeyState = [u8; (ROWS * COLUMNS + 2) / 8]; // [u8; 9]
 
 pub struct KeyMatrix {

--- a/src/keymatrix.rs
+++ b/src/keymatrix.rs
@@ -28,11 +28,11 @@ type ColumnPins = (
     PB5<Output>,
 );
 
-/// The currently pressed down keys
+/// State of the keymatrix.
 ///
 /// A 72-bit array where the most-significant 2 bits are unused.
 /// Each key's state is stored as 1 (pressed) or 0 (released) at
-/// the bit indexed by the corresponding `keycodes::KeyIndex`,
+/// the bit indexed by the corresponding [`keycodes::KeyIndex`],
 /// namely Escape is at bit 0 (least-significant bit), and RCtrl
 /// is at bit 69.
 ///

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,4 +1,4 @@
-use super::keymatrix::{to_packed_bits, KeyState};
+use super::keymatrix::KeyState;
 use super::protocol::{LedOp, Message, MsgType};
 use super::serial::led_usart::LedUsart;
 use super::serial::{Serial, Transfer};
@@ -100,9 +100,7 @@ where
     }
 
     pub fn send_keys(&mut self, state: &KeyState) -> nb::Result<(), !> {
-        let packed = to_packed_bits(state);
-        self.serial
-            .send(MsgType::Led, LedOp::Key as u8, &packed.bytes)
+        self.serial.send(MsgType::Led, LedOp::Key as u8, state)
     }
 
     pub fn send_music(&mut self, keys: &[u8]) -> nb::Result<(), !> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 #![no_std]
 
 extern crate bare_metal;
+extern crate bit_field;
 extern crate cortex_m;
 extern crate cortex_m_rtfm as rtfm;
 extern crate cortex_m_semihosting;


### PR DESCRIPTION
close #27 

Should `ROWS` and `COLUMNS` be more global? currently `Keyboard::process` has `for key in 0..14 * 5 {`

The square brackets around `keycodes::KeyIndex` will be turned into intra-link when RFC 1946 is implemented.