### PR TITLE
keyboard: manipulate layers with bit_field

### DIFF
--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -22,7 +22,11 @@ pub struct Bluetooth<BUFFER: 'static + Unsize<[u8]>> {
     pub serial: Serial<BluetoothUsart, BUFFER>,
     pub rx_transfer: Option<Transfer<BUFFER>>,
     mode: BluetoothMode,
+    /// 4-bit bitfield, indicating whether the BT chip has a host
+    /// saved in that slot. TODO: investigate high bits (issue #37)
     saved_hosts: u8,
+    /// The currently connected slot (1-4), or disconnected (0), or
+    /// the current host is not saved (12)
     connected_host: u8,
 }
 
@@ -189,13 +193,7 @@ where
                     }
                     BleOp::AckHostListQuery => {
                         if message.data.len() == 3 {
-                            // bitfield, with (four?) bits, each indicating if we've saved a
-                            // connection in that slot
                             self.saved_hosts = message.data[0];
-                            // number of the connected host slot
-                            // 0 = not connected
-                            // 1-4 = connected to host 1-4
-                            // 12? = connected, but not to a saved host
                             self.connected_host = message.data[1];
                             self.mode = match message.data[2] {
                                 0 => BluetoothMode::Ble,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -21,7 +21,7 @@ macro_rules! debug {
 #[cfg(not(feature = "use_semihosting"))]
 #[macro_export]
 macro_rules! debug {
-    ($($arg: tt)*) => {{
+    ($($arg:tt)*) => {{
         let res: Result<(), ()> = Ok(());
         res
     }};

--- a/src/hidreport.rs
+++ b/src/hidreport.rs
@@ -1,6 +1,7 @@
 use core::slice;
 
 #[repr(packed)]
+#[derive(Default)]
 pub struct HidReport {
     pub modifiers: u8,
     _unused: u8,
@@ -8,14 +9,6 @@ pub struct HidReport {
 }
 
 impl HidReport {
-    pub fn new() -> HidReport {
-        HidReport {
-            modifiers: 0,
-            _unused: 0,
-            keys: [0; 6],
-        }
-    }
-
     pub fn as_bytes(&self) -> &[u8] {
         unsafe {
             let p: *const HidReport = self;

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -25,6 +25,10 @@ impl Keyboard {
         }
     }
 
+    /// Get the action for `key`.
+
+    /// The top non-Transparent action at index `key` amongst the
+    /// currently active layers is returned.
     fn get_action(&self, key: usize) -> Action {
         let mut action = Action::Transparent;
 
@@ -108,8 +112,11 @@ trait EventProcessor {
     fn finish(&mut self) {}
 }
 
+/// Bit-field of the currently active layers, indexed by position in
+/// [`layout::LAYERS`].
 struct Layers {
     current: u8,
+    /// Active layers after action processing is finished
     next: u8,
 }
 
@@ -143,6 +150,7 @@ impl EventProcessor for Layers {
 
 struct HidProcessor {
     pub report: HidReport,
+    /// Number of normal keys to be sent in `report`
     i: usize,
 }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -5,7 +5,7 @@ use core::marker::Unsize;
 use debug::UnwrapLog;
 use hidreport::HidReport;
 use keycodes::KeyCode;
-use keymatrix::KeyState;
+use keymatrix::{KeyState, COLUMNS, ROWS};
 use layout::LAYERS;
 use layout::LAYER_BT;
 use led::Led;
@@ -58,7 +58,7 @@ impl Keyboard {
         if &self.previous_state != state {
             let mut hid = HidProcessor::new();
 
-            for key in 0..14 * 5 {
+            for key in 0..COLUMNS * ROWS {
                 let pressed = state.get_bit(key);
                 let changed = self.previous_state.get_bit(key) != pressed;
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -56,7 +56,7 @@ impl Keyboard {
     {
         // TODO: might not even need this check after switching to wakeup only handling?
         if &self.previous_state != state {
-            let mut hid = HidProcessor::new();
+            let mut hid = HidProcessor::default();
 
             for key in 0..COLUMNS * ROWS {
                 let pressed = state.get_bit(key);
@@ -150,19 +150,11 @@ impl EventProcessor for Layers {
     }
 }
 
+#[derive(Default)]
 struct HidProcessor {
     pub report: HidReport,
     /// Number of normal keys to be sent in `report`
     i: usize,
-}
-
-impl HidProcessor {
-    fn new() -> HidProcessor {
-        HidProcessor {
-            report: HidReport::new(),
-            i: 0,
-        }
-    }
 }
 
 impl EventProcessor for HidProcessor {

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -127,7 +127,7 @@ impl KeyCode {
     }
 }
 
-// Index of each physical Key in the scan matrix
+/// Index of each physical key in the scan matrix
 #[cfg_attr(rustfmt, rustfmt_skip)]
 pub enum KeyIndex {
     Escape,   N1,    N2,   N3,  N4,  N5,    N6,  N7,  N8,    N9,   N0,     Minus,    Equal,    BSpace,

--- a/src/keymatrix.rs
+++ b/src/keymatrix.rs
@@ -7,8 +7,8 @@ use hal::gpio::gpiob::*;
 use hal::gpio::{Input, Output};
 use stm32l151::SYST;
 
-const ROWS: usize = 5;
-const COLUMNS: usize = 14;
+pub const ROWS: usize = 5;
+pub const COLUMNS: usize = 14;
 
 type RowPins = (PB9<Input>, PB8<Input>, PB7<Input>, PB6<Input>, PA0<Input>);
 type ColumnPins = (

--- a/src/keymatrix.rs
+++ b/src/keymatrix.rs
@@ -28,16 +28,16 @@ type ColumnPins = (
     PB5<Output>,
 );
 
-/// State of the keymatrix.
+/// State of the scan matrix
 ///
-/// A 72-bit array where the most-significant 2 bits are unused.
-/// Each key's state is stored as 1 (pressed) or 0 (released) at
-/// the bit indexed by the corresponding [`keycodes::KeyIndex`],
-/// namely Escape is at bit 0 (least-significant bit), and RCtrl
-/// is at bit 69.
+/// A 72-bit array whose most-significant 2 bits are unused.  Each
+/// key's state is stored as 1 (pressed) or 0 (released) at the bit
+/// indexed by the corresponding [`keycodes::KeyIndex`], namely
+/// `Escape` is at bit 0 (least-significant bit), and `RCtrl` is at
+/// bit 69.
 ///
-/// This packed format is used as-is when sending key-state to
-/// stock LED firmware.
+/// This packed format is sent as-is to stock LED firmware for theme
+/// activation.
 pub type KeyState = [u8; (ROWS * COLUMNS + 2) / 8]; // [u8; 9]
 
 pub struct KeyMatrix {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,7 @@
 use action::Action;
 use action::Action::*;
 use keycodes::KeyCode::*;
+use keymatrix::{COLUMNS, ROWS};
 
 /*
   ,-----------------------------------------------------------------------------.
@@ -16,7 +17,7 @@ use keycodes::KeyCode::*;
   `-----------------------------------------------------------------------------'
 */
 
-pub type Layout = [Action; 70];
+pub type Layout = [Action; COLUMNS * ROWS];
 
 pub const LAYERS: [Layout; 4] = [BASE, FN, FN2, BT];
 

--- a/src/led.rs
+++ b/src/led.rs
@@ -155,7 +155,7 @@ where
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let payload = &[0xca,
-                        0x13, // the following data's length
+                        19, // the number of keys in this request
             KeyIndex::Escape as u8, 0xff, 0xff, 0x00, LedMode::On as u8,
             // Select host
             KeyIndex::N1 as u8,     cu, 0xff, c1, LedMode::On as u8,
@@ -187,7 +187,7 @@ where
     pub fn bluetooth_pin_mode(&mut self) -> nb::Result<(), !> {
         #[cfg_attr(rustfmt, rustfmt_skip)]
         let payload = &[0xca,
-                        11, // the following data's length
+                        11, // the number of keys in this request
             KeyIndex::N1 as u8, 0x00, 0xff, 0x00, LedMode::On as u8,
             KeyIndex::N2 as u8, 0x00, 0xff, 0x00, LedMode::On as u8,
             KeyIndex::N3 as u8, 0x00, 0xff, 0x00, LedMode::On as u8,

--- a/src/led.rs
+++ b/src/led.rs
@@ -70,12 +70,11 @@ where
 
     pub fn toggle(&mut self) -> nb::Result<(), !> {
         self.state = !self.state;
-        let result = if self.state {
+        if self.state {
             self.theme_mode()
         } else {
             self.set_theme(0)
-        };
-        result
+        }
     }
 
     // next_* cycles through themes/brightness/speed


### PR DESCRIPTION
This PR replaces manual bit-twiddling in layers-processing with `bit_field`'s method. I will also fill out the relevant structs' documentation as I go along.