### PR TITLE
get thumbv7m std via rustup

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,3 +6,6 @@ rustflags = [
   "-Z", "linker-flavor=ld",
   "-Z", "thinlto=no",
 ]
+
+[build]
+target = "thumbv7m-none-eabi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ script:
 
 cache:
   cargo: true
-  directories:
-    - $HOME/.xargo
 
 before_cache:
   # Travis can't cache files that are not readable by "others"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
-XARGO = xargo
-
 all:
 	$(MAKE) dfu
 
 build:
-	$(XARGO) build --release --target thumbv7m-none-eabi
+	cargo build --release
 
 dfu: build
 	./scripts/generate_dfu.sh
@@ -16,16 +14,16 @@ openocd:
 	openocd -f openocd.cfg
 
 bloat:
-	$(XARGO) bloat --target thumbv7m-none-eabi $(BLOAT_ARGS) -n 50
+	cargo bloat $(BLOAT_ARGS) -n 50
 
 fmt:
 	cargo fmt
 
 clippy:
-	$(XARGO) clippy --target thumbv7m-none-eabi
+	cargo clippy
 
 clean:
-	$(XARGO) clean
+	cargo clean
 	rm -f anne-key.bin
 	rm -f anne-key.dfu
 	rm -rf book/

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ Many fellow projects provide insights into the obins firmware and app protocol:
 - qmk ports: [josecostamartins'](https://github.com/josecostamartins/qmk_firmware/commits/anne_pro) and [dwhinham's](https://github.com/dwhinham/qmk_firmware/commits/anne_pro)
 
 
-To build your own firmware, you need [xargo](https://github.com/japaric/xargo) with the following components:
+To build your own firmware, you need the nightly rust toolchain with
+the following components:
 
 - nightly rust as default: `rustup default nightly`
-- rust-src: `rustup component add rust-src --toolchain nightly`
-- xargo itself: `cargo +nightly install xargo`
+- thumbv7m std: `rustup target add thumbv7m-none-eabi`
 - ARM linker: usually named `arm-none-eabi-ld`, please check with your OS
 
 Then, `make dfu` in the top directory will build your `anne-key.dfu`.
@@ -122,3 +122,8 @@ To analyze the firmware's code size, you need [cargo-bloat](https://github.com/R
 - `cargo install cargo-bloat`
 - `make bloat`
 - `make bloat BLOAT_ARGS="--crates" # passing arguments to cargo-bloat`
+
+Our CI requires consistent formatting, please run rustfmt before you submit PRs:
+
+- `rustup component add rustfmt-preview`
+- `make fmt`

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,6 +1,0 @@
-[dependencies.core]
-stage = 0
-
-[dependencies.compiler_builtins]
-features = ["mem"]
-stage = 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,22 +3,8 @@
 set -eux
 
 main() {
-        # This fetches latest stable release of Xargo
-        local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/xargo \
-                        | cut -d/ -f3 \
-                        | grep -E '^v[0.3.0-9.]+$' \
-                        | sort --version-sort \
-                        | tail -n1)
-
-        curl -LSfs https://japaric.github.io/trust/install.sh | \
-            sh -s -- \
-               --force \
-               --git japaric/xargo \
-               --tag $tag \
-               --target x86_64-unknown-linux-musl
-
-        rustup component list | grep 'rust-src.*installed' || \
-            rustup component add rust-src
+        rustup component list | grep 'thumbv7m.*installed' || \
+            rustup target add thumbv7m-none-eabi
 
         rustup component list | grep 'rustfmt.*installed' || \
             rustup component add rustfmt-preview


### PR DESCRIPTION
japaric has landed THUMB std in nightly-2018-04-08.

However, due to https://users.rust-lang.org/t/psa-breaking-change-extern-crate-compiler-builtins-is-now-included-in-no-std-crates/16704 the user needs to remove Cargo.lock when pulling in this commit, otherwise they will get:

```
error[E0259]: the name `compiler_builtins` is defined multiple times
   --> .../.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.3.13/src/lib.rs:496:1
    |
496 | extern crate compiler_builtins;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `compiler_builtins` reimported here
```

I have also verified that RLS works with the `.cargo/config` `build.target` change (cc #43)