### PR TITLE
start openocd from inside gdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 *#
 .gdb_history
+openocd.log
 *.bin
 *.dfu
 target/

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ debug: build-semihosting
 gui-debug: build-semihosting
 	gdbgui --gdb $(GDB) --gdb-args "-x openocd.gdb" target/thumbv7m-none-eabi/release/anne-key
 
-openocd:
-	openocd -f openocd.cfg
-
 bloat:
 	cargo bloat $(BLOAT_ARGS) -n 50 --target thumbv7m-none-eabi
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -45,11 +45,11 @@ OpenOCD
 For the best experience, use a new opencd with a unified
 `interface/stlink.cfg` (0.11, not yet released). Otherwise you will
 need to specify the precise ST-Link version in `openocd.cfg`.  Once
-your programmer is connected, start the gdbserver with `make openocd`.
-
-In another console, `make debug` will build a semihosting-enabled
-binary and run `arm-none-eabi-gdb` over the gdbserver connection. You
-can use another debugger by setting the `GDB` variable:
+your programmer is connected, `make debug` will build a
+semihosting-enabled binary, then use `arm-none-eabi-gdb` and `openocd`
+to load it into the keyboard. The semihosting output is logged into
+`openocd.log`, but it will be cleared with each run. You can use
+another debugger by setting the `GDB` variable:
 
 ```sh
 env GDB=gdb-multiarch make debug

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,6 +1,8 @@
 telnet_port disabled
 tcl_port disabled
 
+# TODO(hdhoang): find a way to differentiate between key chip and LED
+# chip
 source [find interface/stlink-v2-1.cfg]
 source [find board/st_nucleo_l1.cfg]
 reset_config none separate

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,3 +1,6 @@
+telnet_port disabled
+tcl_port disabled
+
 source [find interface/stlink-v2-1.cfg]
 source [find board/st_nucleo_l1.cfg]
 reset_config none separate

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -1,6 +1,6 @@
 set history save on
 add-auto-load-safe-path ~/.rustup/toolchains
-target remote :3333
+target remote | openocd -c "gdb_port pipe; log_output openocd.log" -f openocd.cfg
 set print asm-demangle on
 monitor arm semihosting enable
 


### PR DESCRIPTION
Besides being simpler to setup, this removes one pain point in using multiple programmers (e.g. for key and led at once). Not that I have attempted to connect both.