### PR TITLE
grabbag update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,8 @@ dependencies = [
  "nb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-abort 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-semihosting 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stm32l1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "stm32l151-hal 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stm32l1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stm32l151-hal 0.6.0 (git+https://github.com/hdhoang/stm32l151-hal?branch=stm32l1-0.5)",
  "vcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -281,7 +281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stm32l1"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bare-metal 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,13 +292,13 @@ dependencies = [
 
 [[package]]
 name = "stm32l151-hal"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.6.0"
+source = "git+https://github.com/hdhoang/stm32l151-hal?branch=stm32l1-0.5#bf69676077d64c89d6f26c9af88765ad8a4023ae"
 dependencies = [
  "cortex-m 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedded-hal 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stm32l1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stm32l1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -414,8 +414,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum stm32l1 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c213236e5dad14da3c96fb08c4eb395fefd38d6dd9d1373a89c2eb314b69b781"
-"checksum stm32l151-hal 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97bdc4d7c7b912c360bc1dc3114a4ec1620991b64c08ffe701e5cd934d7817c5"
+"checksum stm32l1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edda4346740d0f01082c353dca33b320e84f9fb51765fdcac7a624017c5a8ff4"
+"checksum stm32l151-hal 0.6.0 (git+https://github.com/hdhoang/stm32l151-hal?branch=stm32l1-0.5)" = "<none>"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,19 +26,19 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -47,8 +47,8 @@ name = "backtrace-sys"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -98,16 +98,16 @@ name = "cortex-m-rt-macros"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cortex-m-rtfm"
 version = "0.3.4"
-source = "git+https://github.com/hdhoang/cortex-m-rtfm?branch=v0.3-with-cortex-m-v0.5#493f71943a0d983d636f89135a88dd141b5e80d5"
+source = "git+https://github.com/hdhoang/cortex-m-rtfm?branch=v0.3-with-cortex-m-v0.5#d9d1134ac9c90cc1e97877049864c62f9d067cba"
 dependencies = [
  "cortex-m 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m-rt 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -119,11 +119,11 @@ dependencies = [
 [[package]]
 name = "cortex-m-rtfm-macros"
 version = "0.3.2"
-source = "git+https://github.com/hdhoang/cortex-m-rtfm?branch=v0.3-with-cortex-m-v0.5#493f71943a0d983d636f89135a88dd141b5e80d5"
+source = "git+https://github.com/hdhoang/cortex-m-rtfm?branch=v0.3-with-cortex-m-v0.5#d9d1134ac9c90cc1e97877049864c62f9d067cba"
 dependencies = [
- "failure 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rtfm-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -152,27 +152,27 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.45"
+version = "0.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.24"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -204,10 +204,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -217,23 +217,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -246,16 +246,16 @@ name = "rtfm-syntax"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -306,18 +306,18 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.23"
+version = "0.15.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -326,9 +326,9 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -381,12 +381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aligned 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d39da9b88ae1a81c03c9c082b8db83f1d0e93914126041962af61034ab44c4a5"
-"checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
-"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bare-metal 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a3caf393d93b2d453e80638d0674597020cef3382ada454faacd43d1a55a735a"
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
-"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
+"checksum cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cortex-m 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dab2164a0fc216781a47fc343347365112ae6917421d3fa4bac6faf0fbaaaec7"
 "checksum cortex-m-rt 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f69d2beca37acc3776c17201c9d1f8904fb9139fa3a4d2cf28c8436a07b21a88"
@@ -394,30 +394,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cortex-m-rtfm 0.3.4 (git+https://github.com/hdhoang/cortex-m-rtfm?branch=v0.3-with-cortex-m-v0.5)" = "<none>"
 "checksum cortex-m-rtfm-macros 0.3.2 (git+https://github.com/hdhoang/cortex-m-rtfm?branch=v0.3-with-cortex-m-v0.5)" = "<none>"
 "checksum cortex-m-semihosting 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1dc2abec1a772e8bb697cad17d5710f180043caf8939820f0f6ba4b7ae2a4b5"
-"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum embedded-hal 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9880e55238830314d41d88f1ac7a819d495799c3cc3bc392cc172bab26428c33"
-"checksum failure 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e945b93ec214c6e97b520ec6c5d80267fc97af327658ee5b9f35984626e51fbf"
-"checksum failure_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7c395a14ab27b42704e85bf2435c5c51f334ad7a96e16fe23c6e63a1cad6cc12"
-"checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)" = "413f3dfc802c5dc91dc570b05125b6cda9855edfaa9825c9849807876376e70e"
 "checksum nb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "69f380b5fe9fab8c0d7a6a99cda23e2cc0463bedb2cbc3aada0813b98496ecdc"
 "checksum panic-abort 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c14a66511ed17b6a8b4256b868d7fd207836d891db15eea5195dbcaf87e630f"
 "checksum panic-semihosting 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a647d81e7b00f69deac766cd96d69fc11c95c18657d2448b539ae93e4c558689"
-"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
-"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum r0 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
-"checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
-"checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
-"checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum rtfm-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ba440da895db782b3e459c39316133e36ee13c60a836bb99f7df4940beb441"
 "checksum rtfm-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "820448648d3adb35aadaeaccf8536eae97008ca47f36078a0791878402cae6bd"
-"checksum rustc-demangle 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "01b90379b8664dd83460d59bdc5dd1fd3172b8913788db483ed1325171eab2f7"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum stm32l1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edda4346740d0f01082c353dca33b320e84f9fb51765fdcac7a624017c5a8ff4"
 "checksum stm32l151-hal 0.6.0 (git+https://github.com/hdhoang/stm32l151-hal?branch=stm32l1-0.5)" = "<none>"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum untagged-option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89553f60895e868761e18120e72077da22920614562d2f4fe98fa707fbb12fe6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ branch = "v0.3-with-cortex-m-v0.5"
 
 [dependencies.hal]
 package = "stm32l151-hal"
-version = "0.5.0"
+git = "https://github.com/hdhoang/stm32l151-hal"
+branch = "stm32l1-0.5"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
@@ -33,7 +34,7 @@ version = "0.2.2"
 
 [dependencies.stm32l1]
 features = ["stm32l151", "rt"]
-version = "0.3.2"
+version = "0.5"
 
 [dependencies.panic-abort]
 version = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,12 @@ To analyze the firmware's code size, you need [cargo-bloat](https://github.com/R
 - `make bloat`
 - `make bloat BLOAT_ARGS="--crates" # passing arguments to cargo-bloat`
 
-Our CI requires consistent formatting, please run rustfmt before you submit PRs:
+Our CI requires consistent formatting, please use our pre-commit hook
+to make sure:
+
+- `cp scripts/pre-commit .git/hooks/pre-commit`
+
+To fix formatting:
 
 - `make fmt`
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -47,9 +47,10 @@ For the best experience, use a new opencd with a unified
 need to specify the precise ST-Link version in `openocd.cfg`.  Once
 your programmer is connected, `make debug` will build a
 semihosting-enabled binary, then use `arm-none-eabi-gdb` and `openocd`
-to load it into the keyboard. The semihosting output is logged into
-`openocd.log`, but it will be cleared with each run. You can use
-another debugger by setting the `GDB` variable:
+to load it into the keyboard. The semihosting output is printed to
+gdb's console, and OpenOCD's messages are logged into
+`openocd.log`. You can use another debugger by setting the `GDB`
+variable:
 
 ```sh
 env GDB=gdb-multiarch make debug

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -1,6 +1,6 @@
 set history save on
 add-auto-load-safe-path ~/.rustup/toolchains
-target remote | openocd -c "gdb_port pipe; log_output openocd.log" -f openocd.cfg
+target extended-remote | openocd -c "gdb_port pipe; log_output openocd.log" -f openocd.cfg
 set print asm-demangle on
 monitor arm semihosting enable
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+cargo fmt --all -- --check

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -153,7 +153,7 @@ where
                             .log_error();
                     }
                     _ => {
-                        debug!("msg: System {} {:?}", message.operation, message.data).ok();
+                        crate::heprintln!("msg: System {} {:?}", message.operation, message.data).ok();
                     }
                 }
             }
@@ -166,28 +166,28 @@ where
                     BleOp::AckOn => {
                         // data = [0]
                         // TODO: always getting a [0] too much?
-                        //debug!("bt ack on: {:?}", message.data).ok();
+                        //crate::heprintln!("bt ack on: {:?}", message.data).ok();
                     }
                     BleOp::AckOff => {
                         // data = [0]
-                        //debug!("bt ack off: {:?}", message.data).ok();
+                        //crate::heprintln!("bt ack off: {:?}", message.data).ok();
                     }
                     BleOp::AckLegacyMode => {
                         // data = [0]
-                        //debug!("bt ack legacy mode: {:?}", message.data).ok();
+                        //crate::heprintln!("bt ack legacy mode: {:?}", message.data).ok();
                     }
                     BleOp::AckDeleteHost => {
                         // data = [0]
-                        //debug!("bt ack delete host: {:?}", message.data).ok();
+                        //crate::heprintln!("bt ack delete host: {:?}", message.data).ok();
                     }
                     BleOp::Pair => {
-                        debug!("bt pair").ok();
+                        crate::heprintln!("bt pair").ok();
                         keyboard.disable_bluetooth_mode();
                         led.bluetooth_pin_mode().log_error();
                     }
                     BleOp::Disconnect => {
                         // check this? sent after off, 14
-                        debug!("bt disconnect").ok();
+                        crate::heprintln!("bt disconnect").ok();
                     }
                     BleOp::AckHostListQuery => {
                         if message.data.len() == 3 {
@@ -205,7 +205,7 @@ where
                         }
                     }
                     _ => {
-                        debug!("msg: Ble {} {:?}", message.operation, message.data).ok();
+                        crate::heprintln!("msg: Ble {} {:?}", message.operation, message.data).ok();
                     }
                 }
             }
@@ -214,7 +214,7 @@ where
                     led.set_theme(message.data[0]).log_error();
                 }
                 LedOp::GetUserStaticTheme => {
-                    debug!("TODO: Theme Sync").ok();
+                    crate::heprintln!("TODO: Theme Sync").ok();
                     // [data_length, num_blocks, block_i]
                     //let data = [2 + 4, 1, 0, 1, 2, 3, 4];
                     //self.serial
@@ -222,27 +222,27 @@ where
                     //.log_error();
                 }
                 _ => {
-                    debug!("msg: Led {} {:?}", message.operation, message.data).ok();
+                    crate::heprintln!("msg: Led {} {:?}", message.operation, message.data).ok();
                 }
             },
             MsgType::Keyboard => match KeyboardOp::from(message.operation) {
                 KeyboardOp::UpUserLayout => {
-                    debug!("TODO: Keyboard Sync").ok();
+                    crate::heprintln!("TODO: Keyboard Sync").ok();
                 }
                 _ => {
-                    debug!("msg: Keyboard {} {:?}", message.operation, message.data).ok();
+                    crate::heprintln!("msg: Keyboard {} {:?}", message.operation, message.data).ok();
                 }
             },
             MsgType::Macro => match MacroOp::from(message.operation) {
                 MacroOp::SyncMacro => {
-                    debug!("TODO: Macro Sync").ok();
+                    crate::heprintln!("TODO: Macro Sync").ok();
                 }
                 _ => {
-                    debug!("msg: macro {} {:?}", message.operation, message.data).ok();
+                    crate::heprintln!("msg: macro {} {:?}", message.operation, message.data).ok();
                 }
             },
             _ => {
-                debug!(
+                crate::heprintln!(
                     "msg: {:?} {} {:?}",
                     message.msg_type, message.operation, message.data
                 )

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -153,7 +153,8 @@ where
                             .log_error();
                     }
                     _ => {
-                        crate::heprintln!("msg: System {} {:?}", message.operation, message.data).ok();
+                        crate::heprintln!("msg: System {} {:?}", message.operation, message.data)
+                            .ok();
                     }
                 }
             }
@@ -230,7 +231,8 @@ where
                     crate::heprintln!("TODO: Keyboard Sync").ok();
                 }
                 _ => {
-                    crate::heprintln!("msg: Keyboard {} {:?}", message.operation, message.data).ok();
+                    crate::heprintln!("msg: Keyboard {} {:?}", message.operation, message.data)
+                        .ok();
                 }
             },
             MsgType::Macro => match MacroOp::from(message.operation) {
@@ -244,7 +246,9 @@ where
             _ => {
                 crate::heprintln!(
                     "msg: {:?} {} {:?}",
-                    message.msg_type, message.operation, message.data
+                    message.msg_type,
+                    message.operation,
+                    message.data
                 )
                 .ok();
             }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -2,25 +2,9 @@
 // and just ignore bkpts if no debugger attached
 use core::fmt;
 
-#[cfg(feature = "use_semihosting")]
-#[macro_export]
-macro_rules! debug {
-    ($($arg: tt)*) => {
-        {
-            use core::fmt::Write;
-            use cortex_m_semihosting::hio;
-
-            match hio::hstdout() {
-                Ok(ref mut stdout) => write!(stdout, $($arg)*),
-                _ => Ok(())
-            }
-        }
-    }
-}
-
 #[cfg(not(feature = "use_semihosting"))]
 #[macro_export]
-macro_rules! debug {
+macro_rules! heprintln {
     ($($arg:tt)*) => {{
         let res: Result<(), ()> = Ok(());
         res
@@ -36,7 +20,7 @@ impl<E: fmt::Debug> UnwrapLog for Result<(), E> {
     #[cfg(feature = "use_semihosting")]
     fn log_error(self) {
         match self {
-            Err(e) => debug!("{:?}", e).unwrap(),
+            Err(e) => crate::heprintln!("{:?}", e).unwrap(),
             _ => {}
         }
     }

--- a/src/led.rs
+++ b/src/led.rs
@@ -210,17 +210,17 @@ where
                 match LedOp::from(message.operation) {
                     LedOp::AckThemeMode => {
                         // data: [theme id]
-                        //debug!("Led AckThemeMode {:?}", message.data).ok();
+                        //crate::heprintln!("Led AckThemeMode {:?}", message.data).ok();
                     }
                     LedOp::AckConfigCmd => {
                         // data: [theme id, brightness, animation speed]
-                        //debug!("Led AckConfigCmd {:?}", message.data).ok();
+                        //crate::heprintln!("Led AckConfigCmd {:?}", message.data).ok();
                     }
                     LedOp::AckSetIndividualKeys => {
                         // data: [202]
                     }
                     _ => {
-                        debug!(
+                        crate::heprintln!(
                             "lmsg: {:?} {} {:?}",
                             message.msg_type, message.operation, message.data
                         )
@@ -229,7 +229,7 @@ where
                 }
             }
             _ => {
-                debug!(
+                crate::heprintln!(
                     "lmsg: {:?} {} {:?}",
                     message.msg_type, message.operation, message.data
                 )

--- a/src/led.rs
+++ b/src/led.rs
@@ -222,7 +222,9 @@ where
                     _ => {
                         crate::heprintln!(
                             "lmsg: {:?} {} {:?}",
-                            message.msg_type, message.operation, message.data
+                            message.msg_type,
+                            message.operation,
+                            message.data
                         )
                         .ok();
                     }
@@ -231,7 +233,9 @@ where
             _ => {
                 crate::heprintln!(
                     "lmsg: {:?} {} {:?}",
-                    message.msg_type, message.operation, message.data
+                    message.msg_type,
+                    message.operation,
+                    message.data
                 )
                 .ok();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@
 extern crate panic_abort;
 #[cfg(feature = "use_semihosting")]
 extern crate panic_semihosting;
+#[cfg(feature = "use_semihosting")]
+use cortex_m_semihosting::heprintln;
 
-#[macro_use]
 mod debug;
 
 #[macro_use]

--- a/src/usb/mod.rs
+++ b/src/usb/mod.rs
@@ -176,7 +176,7 @@ impl Usb {
             },
             UsbDescriptorType::Debug => None,
             _ => {
-                debug!("get descriptor {:x}", value).ok();
+                crate::heprintln!("get descriptor {:x}", value).ok();
                 None
             }
         };
@@ -279,7 +279,7 @@ impl Usb {
                         self.usb.usb_ep0r.toggle_out();
                     }
                     _ => {
-                        debug!("{:x}", value).ok();
+                        crate::heprintln!("{:x}", value).ok();
                         panic!();
                     }
                 }
@@ -313,7 +313,7 @@ impl Usb {
             }
             _ => {
                 // TODO get descriptor f00rt 82 GetStatus 82
-                debug!("rt {:x} {:?} {:x}", request_type, request, request16).ok();
+                crate::heprintln!("rt {:x} {:?} {:x}", request_type, request, request16).ok();
                 panic!();
             }
         }


### PR DESCRIPTION
- partially upgrade stm32l1: v0.5 is made with svd2rust 0.14, and is the same as stm32-rs/stm32l1xx-hal. This will help with #80 
- use semihosting heprintln: somewhere along the last 2 days I have lost the "WouldBlock" output in gdb. This bring it back
- normal `cargo update` too